### PR TITLE
Server specific names and implement role-based naming

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,27 +20,38 @@ class NickNamer:
         except: 
             self.names_dict = {}
             self.save()
+    
+    def change_role_name(self, role_name: str, server_id):
+        self.names_dict[server_id]["NICKNAMER_ROLE"] = role_name
+        self.save()
+
+    def get_role_name(self, server_id):
+        if server_id in self.names_dict and "NICKNAMER_ROLE" in self.names_dict[server_id]:
+            return self.names_dict[server_id]["NICKNAMER_ROLE"]
+        return
 
     def remember(self, name, server_id) -> bool:
         """Remember a name for a specific server."""
         if server_id not in self.names_dict:
-            self.names_dict[server_id] = []
-        if name.lower() in self.names_dict[server_id]:
+            self.names_dict[server_id] = {}
+            self.names_dict[server_id]["words"] = []
+            self.names_dict[server_id]["NICKNAMER_ROLE"] = "NameChanger"
+        if name.lower() in self.names_dict[server_id]["words"]:
             return False
-        self.names_dict[server_id].append(name)
+        self.names_dict[server_id]["words"].append(name)
         self.save()
         return True
 
     def forget(self, name, server_id):
         """Forget a name for a specific server."""
-        if server_id in self.names_dict and name in self.names_dict[server_id]:
-            self.names_dict[server_id].remove(name)
+        if server_id in self.names_dict and name in self.names_dict[server_id]["words"]:
+            self.names_dict[server_id]["words"].remove(name)
             self.save()
 
     def forget_all(self, server_id):
         """Forget all names for a specific server."""
         if server_id in self.names_dict:
-            self.names_dict[server_id] = []
+            self.names_dict[server_id]["words"] = []
             self.save()
 
     def save(self):
@@ -59,7 +70,9 @@ class NickNamer:
 
     def name_list(self, server_id) -> list:
         """Return a list of names that are remembered for a specific server."""
-        return self.names_dict.get(server_id, [])
+        if server_id not in self.names_dict:
+            return []
+        return self.names_dict[server_id]["words"]
 
     def new_name(self, server_id, n=2) -> str:
         name_list = self.name_list(server_id)
@@ -114,6 +127,19 @@ async def remember(ctx, *name: str):
     if err:
         await ctx.send(f'I could not remember {s.join(err)}')
 
+@bot.command(name="rolename", help="[rolename] role_name - Set the role required")
+async def role_name(ctx, role_name: str = None):
+    # If role_name is not provided, return the current role name.
+    if not role_name:
+        await ctx.send(f'The current role name is {nick.get_role_name(str(ctx.guild.id))}... Can you not read?')
+        return
+    # Check if owner first
+    if not ctx.author.guild_permissions.administrator:
+        await ctx.send("You must be an administrator to use this command... Seek gainful employment instead...")
+        return
+    nick.change_role_name(role_name, str(ctx.guild.id))
+    await ctx.send(f'Okay! I will now require the role {role_name} to change names.')
+
 @bot.command(name="forget", help="[forget] word_to_forget - Forget a word.")
 async def forget(ctx, name: str):
     nick.forget(name, str(ctx.guild.id))
@@ -127,15 +153,15 @@ async def forget_all(ctx):
 @bot.command(name="names", aliases=["words", "n"], help="[names|words|n] - List all words remembered.")
 async def get_names(ctx):
     if not nick.name_list(str(ctx.guild.id)):
-        await ctx.send('I remember... nothing')
+        await ctx.send('I remember... nothing :(')
         return
     s :str = " "
-    await ctx.send(f'I remember... {s.join(nick.name_list(str(ctx.guild.id)))}')
+    await ctx.send(f'I remember... {", ".join(nick.name_list(str(ctx.guild.id)))}')
 
 @bot.command(name="randomizeme", aliases=['randme'], help="[randomizeme|randme] num_of_words - Randomize your nickname.")
 async def randomize_me(ctx, n=2):
-    if not has_role(ctx.author, "NameChanger"):
-        await ctx.send("Sorry, you don't have the required role to change names.")
+    if not has_role(ctx.author, nick.get_role_name(str(ctx.guild.id))):
+        await ctx.send("Sorry, you do not have the " + nick.get_role_name(str(ctx.guild.id)) + " role... Get a job...")
         return
     name: str = nick.new_name(str(ctx.guild.id), n)
     await ctx.send(f"Okay! I'll call {ctx.author.name} {name}!")
@@ -145,8 +171,8 @@ async def randomize_me(ctx, n=2):
 
 @bot.command(name="randomize", aliases=['rand'], help="[randomize|rand] user num_of_words - Randomize someone's nickname")
 async def randomize(ctx, member: discord.Member, n=2):
-    if not has_role(ctx.author, "NameChanger"):
-        await ctx.send("Sorry, you don't have the required role to change names.")
+    if not has_role(member, nick.get_role_name(str(ctx.guild.id))):
+        await ctx.send("Sorry, " + member.name + " doesn't have the " + nick.get_role_name(str(ctx.guild.id)) + " role.")
         return
     name: str = nick.new_name(str(ctx.guild.id), n)
     await ctx.send(f"Okay! I'll call {member.name} {name}!")
@@ -156,17 +182,14 @@ async def randomize(ctx, member: discord.Member, n=2):
 
 @bot.command(name="randomizeall", aliases=['randall'], help="[randomizeall|randall] num_of_words - Randomize everyone's nickname.")
 async def randomize_all(ctx, n: int=2):
-    if not has_role(ctx.author, "NameChanger"):
-        await ctx.send("Sorry, you don't have the required role to change names.")
-        return
     guild = ctx.guild
     member_list: str = ""
     for member in guild.members:
+        if not has_role(member, nick.get_role_name(str(ctx.guild.id))):
+            continue
         if member.bot:
             continue
         if member.id == guild.owner.id:
-            continue
-        if not has_role(member, "NameChanger"):
             continue
         name: str = nick.new_name(str(guild.id), n)
         member_list = member_list + "\n" + (f"I'll call {member.name} {name}!")
@@ -180,8 +203,8 @@ async def randomize_all(ctx, n: int=2):
 async def flip(ctx, member: discord.Member=""):
     if not member:
         member = ctx.author
-    if not has_role(member, "NameChanger"):
-        await ctx.send("Sorry, you don't have the required role to change names.")
+    if not has_role(member, nick.get_role_name(str(ctx.guild.id))):
+        await ctx.send("Ain't no way I'm doing that for you.")
         return
     words = member.nick.split()
     reversed_words = words[::-1]

--- a/src/main.py
+++ b/src/main.py
@@ -153,10 +153,10 @@ async def forget_all(ctx):
 @bot.command(name="names", aliases=["words", "n"], help="[names|words|n] - List all words remembered.")
 async def get_names(ctx):
     if not nick.name_list(str(ctx.guild.id)):
-        await ctx.send('I remember... nothing :(')
+        await ctx.send('🤔 I remember... nothing :(')
         return
     s :str = " "
-    await ctx.send(f'I remember... {", ".join(nick.name_list(str(ctx.guild.id)))}')
+    await ctx.send(f'🤔 I remember... \n\n```{" ".join(nick.name_list(str(ctx.guild.id)))}```')
 
 @bot.command(name="randomizeme", aliases=['randme'], help="[randomizeme|randme] num_of_words - Randomize your nickname.")
 async def randomize_me(ctx, n=2):
@@ -164,7 +164,7 @@ async def randomize_me(ctx, n=2):
         await ctx.send("Sorry, you do not have the " + nick.get_role_name(str(ctx.guild.id)) + " role... Get a job...")
         return
     name: str = nick.new_name(str(ctx.guild.id), n)
-    await ctx.send(f"Okay! I'll call {ctx.author.name} {name}!")
+    await ctx.send(f"We will all call {member.name} _{name}_!")
     r = await set_name(ctx.author, name)
     if not r:
         await ctx.send("Something happened :(")
@@ -175,7 +175,7 @@ async def randomize(ctx, member: discord.Member, n=2):
         await ctx.send("Sorry, " + member.name + " doesn't have the " + nick.get_role_name(str(ctx.guild.id)) + " role.")
         return
     name: str = nick.new_name(str(ctx.guild.id), n)
-    await ctx.send(f"Okay! I'll call {member.name} {name}!")
+    await ctx.send(f"We will all call {member.name} _{name}_!")
     r = await set_name(member, name)
     if not r:
         await ctx.send("Something happened :(")
@@ -192,12 +192,12 @@ async def randomize_all(ctx, n: int=2):
         if member.id == guild.owner.id:
             continue
         name: str = nick.new_name(str(guild.id), n)
-        member_list = member_list + "\n" + (f"I'll call {member.name} {name}!")
+        member_list = member_list + "\n" + (f"We will all call {member.name} _{name}_!")
         r: bool = await set_name(member, name)
         if not r:
             await ctx.send(f"Something happened processing - {member.name} :(")
             return
-    await ctx.send(f"Okay, I'm doing it!\n{member_list}")
+    await ctx.send(f"Okay, it's a party!\n{member_list}")
 
 @bot.command(name="flip", help="[flip]")
 async def flip(ctx, member: discord.Member=""):
@@ -208,9 +208,12 @@ async def flip(ctx, member: discord.Member=""):
         return
     words = member.nick.split()
     reversed_words = words[::-1]
-    r = await set_name(member, ' '.join(reversed_words))
+    old_nick = member.nick
+    new_nick = ' '.join(reversed_words)
+    r = await set_name(member, new_nick)
     if not r:
         await ctx.send("Something happened :(")
+    await ctx.send(f"Okay! I flipped {member.name} from _{old_nick}_ to _{new_nick}_!")
 
 @bot.command(name="reloadnames", aliases=['rl'], help="[reloadnames|rl] - Re-read data from disk.")
 async def reload_names(ctx):


### PR DESCRIPTION
This pull request primarily modifies the `NickNamer` class and related bot commands in `src/main.py` to handle server-specific lists of names. The changes include replacing the `names_list` attribute with a dictionary, `names_dict`, that maps server IDs to their respective lists of names and roles. Several methods have been updated to work with this new structure, and some new methods and commands have been added to handle server-specific operations.



Here are the most important changes:

Changes to `NickNamer` class:

* [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L17-R60): The `names_list` attribute was replaced with `names_dict` to handle server-specific lists. The `remember`, `forget`, `forget_all`, `name_list`, `new_name`, and `has_names` methods were updated to accept a `server_id` argument and interact with `names_dict` instead of `names_list`. Additional methods `change_role_name` and `get_role_name` were added to handle role names. [[1]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L17-R60) [[2]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L54-R88)

Changes to bot commands:

* [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L99-R242): The `remember`, `forget`, `forget_all`, `get_names`, `randomize_me`, `randomize`, `randomize_all`, and `flip` commands were updated to handle server-specific names and roles. A new command `role_name` was added to set the role required.

Changes to helper functions:

* [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R113-R116): A new helper function `has_role` was added to check if a member has a specific role.